### PR TITLE
Fixes to provide pathname management

### DIFF
--- a/DirectorySelectButton.py
+++ b/DirectorySelectButton.py
@@ -58,24 +58,11 @@ class DirectorySelectButton(object):
         if directoryName == "":
             return
 
-        self.directoryName = directoryName
+        self.directoryName = os.path.normpath(directoryName)
         self.master.lastFileLoc = self.directoryName
         
         #update the Gui
-        directoryRoots = self.directoryName.split("/")
-        displayDirectory = str()
-
-        while len(directoryRoots) != 0:
-            currentLine = directoryRoots.pop(0)
-
-            if len(directoryRoots) != 0:
-                while len(currentLine) + len(directoryRoots[0]) < self.width:
-                    currentLine = "{}\\{}".format(currentLine, directoryRoots.pop(0))
-
-                    if len(directoryRoots) == 0:
-                        break
-            
-            displayDirectory = "{}{}".format(displayDirectory, currentLine)
+        displayDirectory = self.directoryName
         
         self.button.config(
             text="{}: {}".format(self.directType, displayDirectory),

--- a/Gui.py
+++ b/Gui.py
@@ -408,7 +408,7 @@ class Gui:
             las_to_process = []
             for slf in split_las_files:
                 if slf.startswith(ot):
-                    las = r'{}\{}'.format(self.lasSplitTileInput.directoryName, slf)
+                    las = os.path.join(self.lasSplitTileInput.directoryName, slf)
                     print('LAS:  {}'.format(las))
                     las_to_process.append(las)
 
@@ -462,8 +462,7 @@ class Gui:
                 self.flight_lines.reshape(num_points, 1)))
 
             output_tpu_file = r'{}_TPU.csv'.format(ot)
-            output_path ='{}\\{}'.format(
-                self.lasInput.directoryName, output_tpu_file)
+            output_path = os.path.join(self.lasInput.directoryName, output_tpu_file)
             print('writing TPU to {}'.format(output_path))
             output_df = pd.DataFrame(output)
             output_df.to_csv(output_path, index=False)
@@ -518,8 +517,7 @@ class Gui:
                 meta_str += '{} - {}\n'.format(j, l)
 
             output_tpu_meta_file = r'{}_TPU.meta'.format(ot)
-            outputMetaFile = open("{}\\{}".format(
-                self.lasInput.directoryName, output_tpu_meta_file), "w")
+            outputMetaFile = open(os.path.join(self.lasInput.directoryName, output_tpu_meta_file), "w")
             outputMetaFile.write(meta_str)
             outputMetaFile.close()
 

--- a/calc_aerial_TPU.py
+++ b/calc_aerial_TPU.py
@@ -326,7 +326,6 @@ def main(sbets_df, las_files):
     directory choosing code changed to parameters for compatibility with GUI
     """
 
-    # las_files = ['\\'.join([las_dir, l]) for l in os.listdir(las_dir)]
     num_las = len(las_files)
 
     # calculate M and R matrices

--- a/load_sbet.py
+++ b/load_sbet.py
@@ -6,9 +6,7 @@ from datetime import datetime
 
 # get sbet date from file name
 def get_sbet_date(sbet):
-
-    sbet_parts = sbet.split('\\')
-    sbet_name = sbet_parts[-1]
+    sbet_name = os.path.basename(sbet)
     year = int(sbet_name[0:4])
     month = int(sbet_name[4:6])
     day = int(sbet_name[6:8])
@@ -69,10 +67,8 @@ def build_sbets_data(sbet_files):
 
 
 def main(sbet_dir):
-
-    sbet_files = sorted(['{}\{}'.format(sbet_dir, f) for f in os.listdir(sbet_dir)
+    sbet_files = sorted([os.path.join(sbet_dir, f) for f in os.listdir(sbet_dir)
                          if f.endswith('.txt')])
-
     sbet_tic = time.clock()
     sbets_df = build_sbets_data(sbet_files)
     sbet_toc = time.clock()

--- a/pre_TPU_tile_processing.py
+++ b/pre_TPU_tile_processing.py
@@ -44,48 +44,48 @@ def get_num_points(las):
 
 
 def get_las_files(las_dir, contains):
-    las_files = ['\\'.join([las_dir, f]) for f in os.listdir(las_dir)
+    las_files = [os.path.join(las_dir, f) for f in os.listdir(las_dir)
                  if contains in f and f.endswith('.las')]
 
     return las_files
 
 
 def las2las(i, las, las_tools_dir):
-    las_short_name = las.split('\\')[-1]
+    las_short_name = os.path.basename(las);
     print('extracting class code {} ({}) from {} ({} of {})...'.format(
         classes[class_to_extract], class_to_extract, las_short_name, i+1, len(las_tiles)))
-    las2las_path = r'{}\las2las'.format(las_tools_dir)
-    out_las = '\\'.join([bathy_dir, las_short_name.replace('.las', '_BATHY.las')])
+    las2las_path = os.path.join(las_tools_dir, 'las2las')
+    out_las =  os.path.join(bathy_dir, las_short_name.replace('.las', '_BATHY.las'))
     las2las_cmd = r'{} -i {} -keep_classification {} -o {}'.format(
         las2las_path, las, classes['bathymetry'], out_las)
     returncode, output = run_console_cmd(las2las_cmd)
 
 
 def lassort(i, las, total_num_las, las_tools_dir):
-    las_short_name = las.split('\\')[-1]
+    las_short_name = os.path.basename(las)
     print('sorting {} by gps_time ({} of {})...'.format(
         las_short_name, i, total_num_las))
-    lassort_path = r'{}\lassort'.format(las_tools_dir)
-    out_las = '\\'.join([sorted_dir, las_short_name.replace('BATHY', 'SORTED')])
+    lassort_path = os.path.join(las_tools_dir, 'lassort')
+    out_las = os.path.join(sorted_dir, las_short_name.replace('BATHY', 'SORTED'))
     lassort_cmd = r'{} -i {} -gps_time -o {}'.format(lassort_path, las, out_las)
     returncode, output = run_console_cmd(lassort_cmd)
 
 
 def lassplit(i, las, total_num_las, las_tools_dir, preprocess_dir):
-    las_short_name = las.split('\\')[-1]
+    las_short_name = os.path.basename(las);
     print('splitting {} into flight lines ({} of {})...'.format(
         las_short_name, i, total_num_las))
-    lassplit_path = r'{}\lassplit'.format(las_tools_dir)
+    lassplit_path = os.path.join(las_tools_dir, 'lassplit')
     lassplit_cmd = r'{} -i {} -odir {} -olas'.format(
         lassplit_path, las, preprocess_dir)
     returncode, output = run_console_cmd(lassplit_cmd)
 
 
 def lastile(las, out_dir, las_tools_dir):
-    las_short_name = las.split('\\')[-1]
+    las_short_name = os.path.basename(las)
     print('tiling {} into {}-m tiles...'.format(
         las_short_name, tile_size))
-    lastile_path = r'{}\lastile'.format(las_tools_dir)
+    lastile_path = os.path.join(las_tools_dir, 'lastile')
     lastile_cmd = r'{} -i {} -o {} -tile_size {} -odir {} -olas'.format(
         lastile_path, las, las, tile_size, out_dir)
     returncode, output = run_console_cmd(lastile_cmd)
@@ -103,8 +103,8 @@ def main(las_tools_dir, las_dir, preprocess_dir):
     
     tic = datetime.now()
 
-    bathy_dir = '\\'.join([las_dir, 'TEMP\BATHY'])
-    sorted_dir = '\\'.join([las_dir, 'TEMP\SORTED'])
+    bathy_dir = os.path.join(las_dir, 'TEMP', 'BATHY')
+    sorted_dir = os.path.join(las_dir, 'TEMP', 'SORTED')
 
     tile_size = 250
     class_to_extract = 'bathymetry'
@@ -151,8 +151,7 @@ def main(las_tools_dir, las_dir, preprocess_dir):
     total_num_las = len(las_tiles)  # can grow if any bathy tiles need to be tiled
     curr_ind = 0
     for las_bathy in sorted(las_tiles):
-
-        las_bathy_base = las_bathy.split('\\')[-1][:-4]
+        las_bathy_base = os.path.splitext(os.path.basename(las_bathy))[0]
         num_pts = get_num_points(las_bathy)
 
         if num_pts >= lassort_max_num_pts:
@@ -164,10 +163,10 @@ def main(las_tools_dir, las_dir, preprocess_dir):
             # lassort newly tiled, smaller tiles
             # first, get list of new tiles with basename of original las
             print('sorting newly tiled, smaller bathy tiles...')
-            smaller_bathy_tiles = ['\\'.join([bathy_dir, t])
-                             for t in os.listdir(bathy_dir)
-                             if las_bathy_base in t
-                             and '\\'.join([bathy_dir, t]) != las_bathy]
+            smaller_bathy_tiles = [os.path.join(bathy_dir, t)
+                                    for t in os.listdir(bathy_dir)
+                                    if las_bathy_base in t
+                                    and os.path.join(bathy_dir, t) != las_bathy]
             total_num_las += len(smaller_bathy_tiles) - 1  # -1 to exclude too-big file
             for z, t in enumerate(sorted(smaller_bathy_tiles)):
                 print z
@@ -178,7 +177,7 @@ def main(las_tools_dir, las_dir, preprocess_dir):
             curr_ind += 1
             lassort(curr_ind, las_bathy, total_num_las, las_tools_dir)
 
-    bathy_too_big_file = open('{}\\bathy_too_big.txt'.format(bathy_dir), 'w')
+    bathy_too_big_file = open(os.path.join(bathy_dir, 'bathy_too_big.txt'), 'w')
     for las_bathy in bathy_too_big:
         bathy_too_big_file.write('{}\n'.format(las_bathy))
     bathy_too_big_file.close()
@@ -195,8 +194,7 @@ def main(las_tools_dir, las_dir, preprocess_dir):
     total_num_las = len(las_tiles)  # can grow if any bathy tiles need to be tiled
     curr_ind = 0
     for las_sorted in sorted(las_tiles):
-
-        las_sorted_base = las_sorted.split('\\')[-1][:-4]
+        las_sorted_base = os.path.splitext(os.path.basename(las_sorted))[0]
         num_pts = get_num_points(las_sorted)
 
         if num_pts >= lassplit_max_num_pts:
@@ -208,10 +206,10 @@ def main(las_tools_dir, las_dir, preprocess_dir):
             # lasplit newly tiled, smaller tiles
             # first, get list of new tiles with basename of original las
             print('splitting newly tiled, smaller sorted tiles...')
-            smaller_sorted_tiles = ['\\'.join([sorted_dir, t])
+            smaller_sorted_tiles = [os.path.join(sorted_dir, t)
                                     for t in os.listdir(sorted_dir)
                                     if las_sorted_base in t
-                                    and '\\'.join([sorted_dir, t]) != las_sorted]
+                                    and os.path.join(sorted_dir, t) != las_sorted]
 
             total_num_las += len(smaller_sorted_tiles) - 1  # -1 to exclude too-big file
             for t in sorted(smaller_sorted_tiles):
@@ -232,7 +230,7 @@ def main(las_tools_dir, las_dir, preprocess_dir):
                 las_tools_dir,
                 preprocess_dir)
 
-    sorted_too_big_file = open('{}\\sorted_too_big.txt'.format(sorted_dir), 'w')
+    sorted_too_big_file = open(os.path.join(sorted_dir, 'sorted_too_big.txt'), 'w')
     for las_bathy in sorted_too_big:
         sorted_too_big_file.write('{}\n'.format(las_bathy))
     sorted_too_big_file.close()


### PR DESCRIPTION
This makes sure that the code uses os.path to manage pathnames, rather than doing it with user-code.  This avoids OS-specific path management, which is fragile.  Use of the os.path methods also make the code a little more obvious (e.g., using splitext() rather than a slice: name[:-4]).