### PR TITLE
Improvements and Bug Fixes

### DIFF
--- a/CBlueApp.py
+++ b/CBlueApp.py
@@ -116,11 +116,15 @@ def CBlueApp(controller_configuration):
             sbet_tile = os.path.split(las_file)[-1]
             logging.cblue(f"({sbet_tile}) generating SBET tile...")
             inFile = laspy.read(las_file)
-            west = inFile.header.x_min
-            east = inFile.header.x_max
-            north = inFile.header.y_max
-            south = inFile.header.y_min
-            yield sbet.get_tile_data(north, south, east, west), las_file, jacobian, merge
+            # west = inFile.header.x_min
+            # east = inFile.header.x_max
+            # north = inFile.header.y_max
+            # south = inFile.header.y_min
+            # yield sbet.get_tile_data(north, south, east, west), las_file, jacobian, merge
+
+            time_min = inFile.gps_time.min()
+            time_max = inFile.gps_time.max()
+            yield sbet.get_tile_data_by_time(time_min, time_max), las_file, jacobian, merge
 
     if settings_object.multiprocess == "True":
         p = tpu.run_tpu_multiprocess(num_las, sbet_las_tiles_generator())

--- a/Merge.py
+++ b/Merge.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-August 4th, 2025
+May 12th, 2026
 
 """
 
@@ -41,56 +41,216 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class Merge:
 
     max_allowable_dt = 1.0  # second
 
     def __init__(self, sensor_object):
-
         self.a_std_dev = sensor_object.a_std_dev  # degrees
         self.b_std_dev = sensor_object.b_std_dev  # degrees
         self.std_rho = sensor_object.std_rho
 
-        # logger.merge(f"a std dev: {self.a_std_dev}")
-        # logger.merge(f"b std dev: {self.b_std_dev}")
-        # logger.merge(f"std rho: {self.std_rho}")
+    @staticmethod
+    def _print_match_debug(label, t_las, fl_las_data, idx, mask, t_sbet, idx_out, *,
+                           target=None, tol_t=1e-7, tol_xy=1e-2, tol_z=1e-2):
+        """Optional debug printer for a target point.
 
-    def match_timestamps(self, sbet_data, fl_las_data, num_sbet_pts):
-        """returns sbet timestamps and las timestamps matched based on time
+        target:
+          - None (no debug)
+          - float (GPS time)
+          - tuple (t, x, y, z) to uniquely identify a point
+        """
+        if target is None:
+            return
 
-        :param ndarray sbet_data: SBET data
-        :param ndarray fl_las_data: LAS data
-        :param ndarray num_sbet_pts: number of points in the SBET data
-        :return: Tuple(ndarray, ndarray, ndarray, ndarray)
+        if isinstance(target, (float, int)):
+            matches = np.where(np.isclose(t_las, float(target), atol=tol_t))[0]
+        else:
+            tt, xx, yy, zz = target
+            matches = np.where(
+                np.isclose(t_las, tt, atol=tol_t)
+                & np.isclose(fl_las_data[:, 0], xx, atol=tol_xy)
+                & np.isclose(fl_las_data[:, 1], yy, atol=tol_xy)
+                & np.isclose(fl_las_data[:, 2], zz, atol=tol_z)
+            )[0]
 
-        The returned tuple contains:
-        - idx: indices of the matched sbet and las data
-        - mask: boolean mask indicating which points are valid
-        - max_dt: maximum delta_t between the matched sbet and las data
+        if not matches.size:
+            print(f"\nDEBUG({label}): target not present in this flightline array")
+            return
+
+        i = int(matches[0])
+        print(f"\nDEBUG({label}):")
+        print(" LAS t,x,y,z:", float(t_las[i]), float(fl_las_data[i, 0]), float(fl_las_data[i, 1]), float(fl_las_data[i, 2]))
+        print(" initial idx:", int(idx[i]))
+
+        if 0 < idx[i] < len(t_sbet):
+            print(" SBET prev:", float(t_sbet[idx[i]-1]))
+            print(" SBET next:", float(t_sbet[idx[i]]))
+            print(" dt prev:", float(t_sbet[idx[i]-1] - t_las[i]))
+            print(" dt next:", float(t_sbet[idx[i]] - t_las[i]))
+        else:
+            print(" OUT OF RANGE")
+
+        if idx_out is not None:
+            if bool(mask[i]):
+                print(" FINAL SBET idx:", int(idx_out[i]))
+                print(" FINAL SBET time:", float(t_sbet[int(idx_out[i])]))
+                print(" FINAL dt:", float(t_sbet[int(idx_out[i])] - t_las[i]))
+            else:
+                print(" point masked out")
+
+    def match_timestamps(
+        self,
+        sbet_data,
+        fl_las_data,
+        *,
+        time_round_decimals=7,
+        tie_eps=1e-9,
+        debug_target=None
+    ):
+        """
+        Deterministic SBET↔LAS timestamp matching.
+
+        1) Match by time using integer ticks (avoids float jitter).
+        2) If multiple SBET rows share the chosen tick, break ties by spatial proximity
+        between LAS xyz and SBET xyz.
+
+        Assumes SBET columns:
+        time: col 0
+        x,y,z: cols 3,4,5   (as used later in merge())
+        LAS flightline array columns:
+        x,y,z: cols 0,1,2
+        time: col 3
         """
 
-        # Try to match sbet and las dfs based on timestamps
-        idx = np.searchsorted(sbet_data[:, 0], fl_las_data[:, 3])
+        # --- float times for dt output ---
+        t_sbet_f = np.asarray(sbet_data[:, 0])
+        t_las_f  = np.asarray(fl_las_data[:, 3])
 
-        # logger.merge(f"fl_las_data[:, 3]: {fl_las_data[:, 3]}")
-        # logger.merge(f"sbet_data[:, 0]: {sbet_data[:, 0]}")
+        # --- integer ticks for matching ---
+        scale = int(10 ** int(time_round_decimals))
+        t_sbet_i = np.round(t_sbet_f * scale).astype(np.int64)
+        t_las_i  = np.round(t_las_f  * scale).astype(np.int64)
 
-        # don't use las points outside range of sbet points
-        mask = ne.evaluate("0 < idx") & ne.evaluate("idx < num_sbet_pts")
+        # --- SBET sort by time ticks (stable) ---
+        order = np.argsort(t_sbet_i, kind="mergesort")
+        t_sbet_i_s = t_sbet_i[order]
+        t_sbet_f_s = t_sbet_f[order]
 
-        t_sbet_masked = sbet_data[:, 0][idx[mask]]
-        t_las_masked = fl_las_data[:, 3][mask]
+        # SBET positions in the same sorted order
+        xs_s = np.asarray(sbet_data[:, 3])[order]
+        ys_s = np.asarray(sbet_data[:, 4])[order]
+        zs_s = np.asarray(sbet_data[:, 5])[order]
 
-        # logger.merge(f"t_las_masked: {t_las_masked}")
-        # logger.merge(f"t_sbet_masked: {t_sbet_masked}")
+        # LAS positions
+        xl = np.asarray(fl_las_data[:, 0])
+        yl = np.asarray(fl_las_data[:, 1])
+        zl = np.asarray(fl_las_data[:, 2])
 
-        dt = ne.evaluate("t_sbet_masked - t_las_masked")
-        max_dt = ne.evaluate("max(dt)")  # may be empty
+        # --- time match using searchsorted ---
+        idx = np.searchsorted(t_sbet_i_s, t_las_i, side="left")
 
-        return idx, mask, max_dt
+        mask = (idx > 0) & (idx < len(t_sbet_i_s))
+
+        # DEBUG (PRE): show neighbors using *sorted* SBET float times
+        self._print_match_debug(
+            "pre-nearest",
+            t_las_f,              # float LAS time for printing
+            fl_las_data,          # so (t,x,y,z) matching works
+            idx,
+            mask,
+            t_sbet_f_s,           # SBET times in sorted space for prev/next display
+            None,
+            target=debug_target
+        )
 
 
-    def merge(self, las, fl, sbet_data, fl_unsorted_las_xyztcf, fl_t_argsort, fl_las_idx, sensor_object):
+        if not np.any(mask):
+            return idx, mask, np.array([])
+
+        idx_m = np.clip(idx, 1, len(t_sbet_i_s) - 1)
+
+        prev_i = t_sbet_i_s[idx_m - 1]
+        next_i = t_sbet_i_s[idx_m]
+        d_prev = np.abs(t_las_i - prev_i)
+        d_next = np.abs(next_i - t_las_i)
+
+        tie_eps_ticks = int(round(float(tie_eps) * scale))
+        use_prev = (d_prev < d_next) | (np.abs(d_prev - d_next) <= tie_eps_ticks)
+        idx_m = idx_m.copy()
+        idx_m[use_prev] -= 1
+
+        # idx_s is the chosen SBET index in *sorted* SBET space
+        idx_s = idx_m
+
+        # --- DISAMBIGUATE duplicate SBET ticks by spatial proximity ---
+        chosen_tick = t_sbet_i_s[idx_s]
+
+        # for each chosen tick, find its [left,right) run of equal ticks
+        left = np.searchsorted(t_sbet_i_s, chosen_tick, side="left")
+        right = np.searchsorted(t_sbet_i_s, chosen_tick, side="right")
+        dup = (right - left) > 1
+
+        # only loop over the ambiguous (duplicate) matches — typically small
+        dup_idx = np.where(mask & dup)[0]
+        for j in dup_idx:
+            l = int(left[j]); r = int(right[j])
+            # candidates are SBET rows with exactly the same time tick
+            dx = xs_s[l:r] - xl[j]
+            dy = ys_s[l:r] - yl[j]
+            dz = zs_s[l:r] - zl[j]
+            k = int(np.argmin(dx*dx + dy*dy + dz*dz))
+            idx_s[j] = l + k  # best candidate in sorted SBET space
+
+        # map from sorted SBET space back to original SBET indices
+        idx_out = idx.copy()
+        idx_out[mask] = order[idx_s[mask]]
+
+        # --- optional debug (time or (t,x,y,z)) using your helper if you want ---
+        # if you want to keep your existing debug helper, call it here.
+        
+        # DEBUG (POST): show FINAL using original SBET float times
+        self._print_match_debug(
+            "post-nearest",
+            t_las_f,
+            fl_las_data,
+            idx,
+            mask,
+            t_sbet_f,             # original SBET times so FINAL SBET time prints correctly
+            idx_out,
+            target=debug_target
+        )
+
+        if debug_target is not None:
+            tt, xx, yy, zz = debug_target
+            m = np.where(
+                np.isclose(t_las_f, tt, atol=1e-7) &
+                np.isclose(fl_las_data[:,0], xx, atol=1e-2) &
+                np.isclose(fl_las_data[:,1], yy, atol=1e-2) &
+                np.isclose(fl_las_data[:,2], zz, atol=1e-2)
+            )[0]
+            if m.size:
+                i = int(m[0])
+                if mask[i]:
+                    k = int(idx_out[i])
+                    print("SBET_CHOSEN idx=", k,
+                        "XYZ=", float(sbet_data[k,3]), float(sbet_data[k,4]), float(sbet_data[k,5]),
+                        "RPH=", float(sbet_data[k,6]), float(sbet_data[k,7]), float(sbet_data[k,8]),
+                        "STDxyz=", float(sbet_data[k,9]), float(sbet_data[k,10]), float(sbet_data[k,11]),
+                        "STDrph=", float(sbet_data[k,12]), float(sbet_data[k,13]), float(sbet_data[k,14]))
+
+
+        dt = t_sbet_f[idx_out[mask]] - t_las_f[mask]
+        max_dt = np.max(np.abs(dt)) if dt.size else np.array([])
+
+        return idx_out, mask, max_dt
+
+
+
+    def merge(self, las_short_name, fl, sbet_data, fl_unsorted_las_xyztcf, fl_las_idx, sensor_object,
+              *, context_label="", debug_target=None,
+              time_round_decimals=7, tie_eps=1e-9):
         """returns sbet & las data merged based on timestamps
 
         The cBLUE TPU calculations require the sbet and las data to be in
@@ -105,12 +265,28 @@ class Merge:
         the time being, if a single datapoint's delta_t exceeds the allowable
         maximum dt, the entire line is ignored.
 
-        :param str las:
-        :param ? fl:
-        :param ? sbet_data:
-        :param Tuple(ndarray)  # TODO: are the parentheses necessary?
-        :return: List[ndarray]
+        Parameters
+        ----------
+        sbet_data : ndarray
+            SBET data.
+        fl_unsorted_las_xyztcf : ndarray
+            Flightline LAS-derived array, columns: x,y,z,t,classification, ...
+        fl_las_idx : ndarray[int]
+            Original LAS point indices for write-back.
+        sensor_object : object
+            Sensor info.
+        context_label : str
+            Optional label for logs (e.g., f"{las_short_name} FL {fl}").
+        debug_target : None | float | (t,x,y,z)
+            Optional debug selector.
+        time_round_decimals : int
+            Decimal rounding for LAS time used in matching.
+        tie_eps : float
+            Tolerance for deterministic tie-break.
 
+        Returns
+        -------
+        (data, stddev, fl_las_idx_masked, raw_class, masked_fan_angle, masked_hawkeye_data)
         The following table lists the contents of the returned list of ndarrays:
 
         =====   =========   ========================    =======
@@ -137,74 +313,97 @@ class Merge:
         18      stdz_sbet   sbet z uncertainty
         =====   =========   ========================    =======
         """
+
         num_sbet_pts = sbet_data.shape[0]
+        if hasattr(logger, "merge"):
+            logger.merge(f"Num SBET points: {num_sbet_pts}")
+        else:
+            logger.info(f"Num SBET points: {num_sbet_pts}")
 
-        logger.merge(f"Num SBET points: {num_sbet_pts}")
+        # Deterministic sort by point values: time primary, x/y/z tie-break.
+        t = fl_unsorted_las_xyztcf[:, 3]
+        x = fl_unsorted_las_xyztcf[:, 0]
+        y = fl_unsorted_las_xyztcf[:, 1]
+        z = fl_unsorted_las_xyztcf[:, 2]
 
-        # sort xyztcf array based on t_idx column
-        idx = fl_t_argsort.argsort()
-        fl_las_data = fl_unsorted_las_xyztcf[idx]
-        fl_las_idx = fl_las_idx[idx]
+        sort_idx = np.argsort(
+            np.round(t, 9),
+            kind="mergesort"   # STABLE SORT
+        )
 
-        # logger.merge(f"fl_las_data[:, 3]: {fl_las_data[:, 3]}")
-        # logger.merge(f"sbet_data[:, 0]: {sbet_data[:, 0]}")
+        fl_las_data = fl_unsorted_las_xyztcf[sort_idx]
+        fl_las_idx = fl_las_idx[sort_idx]
 
         # Try to match sbet and las dfs based on timestamps
-        idx, mask, max_dt = self.match_timestamps(sbet_data, fl_las_data, num_sbet_pts)
+        idx, mask, max_dt = self.match_timestamps(
+            sbet_data,
+            fl_las_data,
+            time_round_decimals=time_round_decimals,
+            tie_eps=tie_eps,
+            debug_target=debug_target,
+        )
 
-        # If the max_dt is too large, or empty, then we cannot merge the data.
+        # If max_dt is too large or empty, then we cannot merge the data. 
         # This is likely due to the LAS data being standard gps time, when we expect adjusted standard gps time.
-        if max_dt > self.max_allowable_dt or max_dt.size == 0:
-
-            # Try converting LAS time data from standard gps time to Adjusted Standard GPS time
+        # Attempt time conversions and re-match.
+        if (isinstance(max_dt, np.ndarray) and max_dt.size == 0) or (not isinstance(max_dt, np.ndarray) and max_dt > self.max_allowable_dt):
+            # Standard GPS -> Adjusted Standard
+            fl_las_data = fl_las_data.copy()
             fl_las_data[:, 3] = fl_las_data[:, 3] - 1e9
+            idx, mask, max_dt = self.match_timestamps(
+                sbet_data,
+                fl_las_data,
+                time_round_decimals=time_round_decimals,
+                tie_eps=tie_eps,
+                debug_target=debug_target,
+            )
 
-            idx, mask, max_dt = self.match_timestamps(sbet_data, fl_las_data, num_sbet_pts)
-
-            # If the max_dt is still too large, or empty, then we cannot merge the data.
-            # This is likely due to the LAS data being in UTC time, when we expect adjusted standard gps time.
-            if max_dt > self.max_allowable_dt or max_dt.size == 0:
-
-                # If the LAS data was in UTC time, then we can try converting it to adjusted standard gps time.
-                # We've already converted the time once to take away - 1e9 seconds, so we can try adding 18 seconds to the time
-                # to account for the leap seconds adjustment.
+            if (isinstance(max_dt, np.ndarray) and max_dt.size == 0) or (not isinstance(max_dt, np.ndarray) and max_dt > self.max_allowable_dt):
+                # UTC -> Adjusted (approx by adding 18s after -1e9)
                 fl_las_data[:, 3] = fl_las_data[:, 3] + 18
+                idx, mask, max_dt = self.match_timestamps(
+                    sbet_data,
+                    fl_las_data,
+                    time_round_decimals=time_round_decimals,
+                    tie_eps=tie_eps,
+                    debug_target=debug_target,
+                )
 
-                idx, mask, max_dt = self.match_timestamps(sbet_data, fl_las_data, num_sbet_pts)
+                if (isinstance(max_dt, np.ndarray) and max_dt.size == 0) or (not isinstance(max_dt, np.ndarray) and max_dt > self.max_allowable_dt):
+                    logging.warning("trajectory and LAS data NOT MERGED")
+                    if context_label:
+                        logging.warning(f"({context_label}) max_dt: {max_dt}")
+                    else:
+                        logging.warning("({} FL {}) max_dt: {}".format(las_short_name, fl, max_dt))
 
-                # If the max_dt is still too large, or empty, then we cannot merge the data.
-                if max_dt > self.max_allowable_dt or max_dt.size == 0:
-                    # We will log a warning and return empty arrays for the data.
                     data = False
                     stddev = False
                     raw_class = False
                     masked_fan_angle = False
                     masked_hawkeye_data = False
 
-                    logging.warning("trajectory and LAS data NOT MERGED")
-                    logging.warning("({} FL {}) max_dt: {}".format(las.las_short_name, fl, max_dt))
                     return (
-                            data,
-                            stddev,
-                            fl_las_idx[mask],
-                            raw_class,
-                            masked_fan_angle,
-                            masked_hawkeye_data
-                        )  # 3rd to last array is masked t_idx
-        
+                        data,
+                        stddev,
+                        fl_las_idx[mask],
+                        raw_class,
+                        masked_fan_angle,
+                        masked_hawkeye_data,
+                    )
+
         data = np.asarray(
             [
-                sbet_data[:, 0][idx[mask]],  # t?
-                fl_las_data[:, 3][mask],  # t
-                fl_las_data[:, 0][mask],  # x
-                fl_las_data[:, 1][mask],  # y
-                fl_las_data[:, 2][mask],  # z
-                sbet_data[:, 3][idx[mask]],  # x?
-                sbet_data[:, 4][idx[mask]],  # y?
-                sbet_data[:, 5][idx[mask]],  # z?
-                np.radians(sbet_data[:, 6][idx[mask]]),  # r?
-                np.radians(sbet_data[:, 7][idx[mask]]),  # p?
-                np.radians(sbet_data[:, 8][idx[mask]]),  # h?
+                sbet_data[:, 0][idx[mask]],              # t_sbet
+                fl_las_data[:, 3][mask],                 # t_las
+                fl_las_data[:, 0][mask],                 # x_las
+                fl_las_data[:, 1][mask],                 # y_las
+                fl_las_data[:, 2][mask],                 # z_las
+                sbet_data[:, 3][idx[mask]],              # x_sbet
+                sbet_data[:, 4][idx[mask]],              # y_sbet
+                sbet_data[:, 5][idx[mask]],              # z_sbet
+                np.radians(sbet_data[:, 6][idx[mask]]),  # roll
+                np.radians(sbet_data[:, 7][idx[mask]]),  # pitch
+                np.radians(sbet_data[:, 8][idx[mask]]),  # heading
             ]
         )
 
@@ -241,10 +440,13 @@ class Merge:
 
             # Unbounded scan angle/fan angle can go past 26 degrees (absolute). 
             # Warn the user if their fan angle exceed maximum allowed fan angle.
-            if not all(i <=26 for i in masked_fan_angle): 
-                logger.merge(f"WARNING: A scan angle exceeds an absolute value of 26 degrees. Subaqueous processing will fail.")
-        elif(sensor_object.type =="single_hawkeye"):
-                
+            if not all(i <= 26 for i in masked_fan_angle):
+                if hasattr(logger, "merge"):
+                    logger.merge("WARNING: A scan angle exceeds an absolute value of 26 degrees. Subaqueous processing will fail.")
+                else:
+                    logger.warning("A scan angle exceeds an absolute value of 26 degrees. Subaqueous processing will fail.")
+
+        elif sensor_object.type == "single_hawkeye":
             masked_hawkeye_data = np.asarray(
                 [
                     fl_las_data[:, 5][mask], # masked scanner_channel

--- a/Sbet.py
+++ b/Sbet.py
@@ -37,6 +37,7 @@ August 4th, 2025
 import os
 import time
 import pandas as pd
+import numpy as np
 from datetime import datetime
 import progressbar
 import logging
@@ -286,6 +287,7 @@ class Sbet:
 
         sbet_tic = time.process_time()
         self.data = self.build_sbets_data()  # df
+        self.data = self.data.sort_values("time").reset_index(drop=True)
         sbet_toc = time.process_time()
         logger.sbet(
             "It took {:.1f} mins to load the trajectory data.".format(
@@ -330,7 +332,7 @@ class Sbet:
         return data
     
     def get_tile_data_by_time(self, start_time, end_time):
-        """queries the sbet data points that lie within the given start and end time
+        """Queries the sbet data points that lie within the given start and end time
 
         One pandas dataframe is created from all of the loaded ASCII sbet files,
         but as each las tile is processed, only the sbet data located within the
@@ -345,18 +347,37 @@ class Sbet:
         :param float end_time: ending timestamp of las tile
         :return: pandas dataframe
         """
+
         time_buff = 20  # seconds buffer to add to start and end time to ensure we capture all relevant trajectory data for the tile
-                        # in case the user didn't account for leap seconds converting to adjusted gps standard time. 
-        
-        time = self.data.time.values
+                        # in case the user didn't account for leap seconds converting to adjusted gps standard time.
+        scale = 10**7   # must match match_timestamps() in merge.py
 
-        start_time -= time_buff
-        end_time += time_buff
+        # --- adjust time bounds ---
+        start_time_adj = start_time - time_buff
+        end_time_adj   = end_time   + time_buff
 
-        # using numexpr for accelerating computations of large arrays
-        data = self.data[
-            ne.evaluate("(time >= start_time) & (time <= end_time)")
-        ]
+        # --- full SBET time array (POSITIONAL) ---
+        t_full = self.data.time.values
+        t_full_i = np.round(t_full * scale).astype(np.int64)
+
+        # --- compute integer bounds ---
+        start_i = int(round(start_time_adj * scale))
+        end_i   = int(round(end_time_adj   * scale))
+
+        # --- find insertion positions (NOT labels) ---
+        pos_lo = np.searchsorted(t_full_i, start_i, side="left")
+        pos_hi = np.searchsorted(t_full_i, end_i,   side="right")
+
+        # --- expand left to include full duplicate cluster ---
+        while pos_lo > 0 and t_full_i[pos_lo - 1] == t_full_i[pos_lo]:
+            pos_lo -= 1
+
+        # --- expand right to include full duplicate cluster ---
+        while pos_hi < len(t_full_i) and t_full_i[pos_hi] == t_full_i[pos_hi - 1]:
+            pos_hi += 1
+
+        # --- final deterministic slice (POSITIONAL) ---
+        data = self.data.iloc[pos_lo:pos_hi]
 
         return data
     

--- a/Sbet.py
+++ b/Sbet.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-August 4th, 2025
+May 12th, 2026
 
 """
 

--- a/Sbet.py
+++ b/Sbet.py
@@ -41,6 +41,8 @@ from datetime import datetime
 import progressbar
 import logging
 import numexpr as ne
+import concurrent.futures
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +164,7 @@ class Sbet:
         =====   =============================================================
         """
 
-        sbets_df = pd.DataFrame()
+        dfs = []
         header_sbet = [
             "time",
             "lon",
@@ -183,13 +185,37 @@ class Sbet:
         # Used for holding processed SBET data if this is the PILLS sensor
         modified_sbet_file = "modified_pills_sbet.txt"
 
+
         print(r"Loading trajectory files...")
-        logger.sbet("loading {} trajectory files...".format(len(self.sbet_files)))
-        for sbet in progressbar.progressbar(
-            sorted(self.sbet_files), redirect_stdout=True
-        ):
-            logger.sbet("-" * 50)
-            logger.sbet("{}...".format(os.path.split(sbet)[-1]))
+        logger.sbet(f"loading {len(self.sbet_files)} trajectory files...")
+
+
+
+        # dtype hints for faster CSV reading
+        dtype_map = {
+            "time": float,
+            "lon": float,
+            "lat": float,
+            "X": float,
+            "Y": float,
+            "Z": float,
+            "roll": float,
+            "pitch": float,
+            "heading": float,
+            "stdX": float,
+            "stdY": float,
+            "stdZ": float,
+            "stdroll": float,
+            "stdpitch": float,
+            "stdheading": float,
+        }
+
+        # Thread-safe progress bar
+        progress = tqdm(total=len(self.sbet_files), desc="SBET Files", unit="file")
+
+        def process_sbet_file(sbet):
+            # Only log file start
+            logger.sbet(f"Processing {os.path.split(sbet)[-1]}")
             sbet_date = self.get_sbet_date(sbet)
 
             # If this is the PILLS sensor, pre-process the sbet data
@@ -198,26 +224,50 @@ class Sbet:
                 self.preprocess_pills_sbet(sbet, modified_sbet_file)
                 # Reassign the SBET file name to the modified file
                 sbet = modified_sbet_file
-
             sbet_df = pd.read_csv(
                 sbet,
                 skip_blank_lines=True,
                 engine="c",
-                delim_whitespace=True,
+                sep=r"\s+",
                 header=None,
                 names=header_sbet,
                 index_col=False,
+                dtype=dtype_map,
             )
-            logger.sbet("({} trajectory points)".format(sbet_df.shape[0]))
-            
             is_sow = self.check_if_sow(sbet_df["time"][0])
             if is_sow:
                 gps_time_adj = self.gps_sow_to_gps_adj(sbet_date, sbet_df["time"])
                 sbet_df["time"] = gps_time_adj
+            progress.update(1)
+            return sbet_df
 
-            sbets_df = sbets_df.append(sbet_df, ignore_index=True)
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            dfs = list(executor.map(process_sbet_file, sorted(self.sbet_files)))
+        progress.close()
 
-        sbets_data = sbets_df.sort_values(["time"], ascending=[1])
+
+        if dfs:
+            sbets_data = pd.concat(dfs, ignore_index=True)
+            # Only sort if more than one file
+            if len(dfs) > 1:
+                n_rows = len(sbets_data)
+                msg_start = f"Sorting concatenated SBET data by time ({n_rows} rows)..."
+                print(msg_start)
+                logger.sbet(msg_start)
+                sort_start = time.process_time()
+                sbets_data = sbets_data.sort_values(["time"], ascending=[1])
+                sort_end = time.process_time()
+                msg_end = f"Sorting complete. Took {(sort_end - sort_start):.2f} seconds."
+                print(msg_end)
+                logger.sbet(msg_end)
+        else:
+            sbets_data = pd.DataFrame(columns=header_sbet)
+
+        if dfs:
+            sbets_data = pd.concat(dfs, ignore_index=True)
+            sbets_data = sbets_data.sort_values(["time"], ascending=[1])
+        else:
+            sbets_data = pd.DataFrame(columns=header_sbet)
 
         #If this was the PILLS sensor and we created a modified SBET file.
         #   Then clean up by deleting the modified_pills_sbet.txt
@@ -279,6 +329,37 @@ class Sbet:
 
         return data
     
+    def get_tile_data_by_time(self, start_time, end_time):
+        """queries the sbet data points that lie within the given start and end time
+
+        One pandas dataframe is created from all of the loaded ASCII sbet files,
+        but as each las tile is processed, only the sbet data located within the
+        las tile limits are sent to the calc_tpu() method.
+
+        To account for las tiles that contain data points from a las flight line
+        whose corresponding trajectory data falls outside of the las tile extents,
+        a buffer is added to the bounds of the tile when retreiving the
+        trajectory data.
+
+        :param float start_time: starting timestamp of las tile
+        :param float end_time: ending timestamp of las tile
+        :return: pandas dataframe
+        """
+        time_buff = 20  # seconds buffer to add to start and end time to ensure we capture all relevant trajectory data for the tile
+                        # in case the user didn't account for leap seconds converting to adjusted gps standard time. 
+        
+        time = self.data.time.values
+
+        start_time -= time_buff
+        end_time += time_buff
+
+        # using numexpr for accelerating computations of large arrays
+        data = self.data[
+            ne.evaluate("(time >= start_time) & (time <= end_time)")
+        ]
+
+        return data
+    
     def preprocess_pills_sbet(self, sbet_file, modified_sbet_file):
         """Pre-process the given PILLS SBET data into the expected cBLUE format so that build_sbets_data()
             will run as expected. 
@@ -330,7 +411,7 @@ class Sbet:
             fp.close()
 
         # Read in the sbet_file and save it to a DataFrame
-        sbet_df = pd.read_csv(modified_sbet_file, delim_whitespace=True, header=None, index_col=False)
+        sbet_df = pd.read_csv(modified_sbet_file, sep=r"\s+", header=None, index_col=False)
 
         # logger.sbet(f"sbet df: {sbet_df}")
         

--- a/Subaerial.py
+++ b/Subaerial.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-August 4th, 2025
+May 12th, 2026
 
 """
 
@@ -324,8 +324,10 @@ class SensorModel:
             "arcsin(((fR1 * rho_x) + (fR4 * rho_y) + (fR7 * rho_z)) / (rho_est * cos(b_est)))"
         )
 
-    def calc_poly_surf_coeffs(self, itv=10):
-        """estimates error model using polynomial surface fitting
+
+    def calc_poly_surf_coeffs(self, itv=10, sel_mask=None):
+        """
+        Estimates error model using polynomial surface fitting.
 
         This method calculates the coefficients of the polynomial-surface
         error model intended to account for the positional errors resulting
@@ -340,17 +342,21 @@ class SensorModel:
         coefficients, for small speed gains in the calculations of the
         coefficients.
 
-        :param a_est:
-        :param b_est:
-        :param dx:
-        :param dy:
-        :param dz:
-        :param itv:
-        :return: list[tuple, tuple, tuple] TODO: verify
+        If sel_mask is provided, use it as the stable subsample selector.
+        Otherwise fall back to positional slicing [::itv].
         """
+        if sel_mask is None:
+            sel = slice(None, None, itv)
+        else:
+            sel_mask = np.asarray(sel_mask, dtype=bool)
+            # fallback if selection is too small (tiny flightline or aggressive itv)
+            if sel_mask.sum() < 20:
+                sel = slice(None, None, itv)
+            else:
+                sel = sel_mask
 
-        B0 = self.b_est[::itv]
-        A0 = self.a_est[::itv]
+        B0 = self.b_est[sel]
+        A0 = self.a_est[sel]
 
         A = np.vstack(
             (
@@ -366,15 +372,15 @@ class SensorModel:
             )
         ).T
 
-        (self.poly_err_surf_coeffs_x, __, __, __) = np.linalg.lstsq(
-            A, self.dx[::itv], rcond=None
-        )
-        (self.poly_err_surf_coeffs_y, __, __, __) = np.linalg.lstsq(
-            A, self.dy[::itv], rcond=None
-        )
-        (self.poly_err_surf_coeffs_z, __, __, __) = np.linalg.lstsq(
-            A, self.dz[::itv], rcond=None
-        )
+        dx = self.dx[sel]
+        dy = self.dy[sel]
+        dz = self.dz[sel]
+
+        (self.poly_err_surf_coeffs_x, __, __, __) = np.linalg.lstsq(A, dx, rcond=None)
+        (self.poly_err_surf_coeffs_y, __, __, __) = np.linalg.lstsq(A, dy, rcond=None)
+        (self.poly_err_surf_coeffs_z, __, __, __) = np.linalg.lstsq(A, dz, rcond=None)
+
+
 
     @staticmethod
     def calcRMSE(data):
@@ -798,10 +804,33 @@ class Jacobian:
         # calculate differece between initial X, Y, and Z estimates and las X, Y, and Z
         self.sensor_model.calc_diff(data[2], data[3], data[4])
 
-        # calculate polynomial surface coefficients to account for differences dx, dy, and dz
-        self.sensor_model.calc_poly_surf_coeffs()
+        # --- stable subsample mask based on point identity (t,x,y,z) ---
+        t_i = np.round(data[1] * 1e7).astype(np.int64)   # 0.1 microsecond ticks
+        x_i = np.round(data[2] * 100).astype(np.int64)   # centimeters
+        y_i = np.round(data[3] * 100).astype(np.int64)
+        z_i = np.round(data[4] * 100).astype(np.int64)
 
-        # precalculate sin and cos of attitude data to simplify evaluation of Jacobian
+        key = (t_i
+            ^ (x_i * np.int64(1000003))
+            ^ (y_i * np.int64(10007))
+            ^ (z_i * np.int64(101))).astype(np.int64)
+
+        # Choose a modulus that guarantees enough points, deterministically.
+        min_pts = 50
+        mod = 10
+        sel_mask = (key % mod) == 0
+
+        # deterministically relax mod until we have enough points
+        while sel_mask.sum() < min_pts and mod > 1:
+            mod -= 1
+            sel_mask = (key % mod) == 0
+
+        # If still too small (tiny flightline), just use all points (only for tiny cases)
+        if sel_mask.sum() < 9:
+            sel_mask[:] = True
+
+        self.sensor_model.calc_poly_surf_coeffs(itv=mod, sel_mask=sel_mask)
+        # print("sel_mask_sum =", int(sel_mask.sum()), "N =", int(sel_mask.size), "mod =", mod)
 
         trig_subs = self.calc_trig_terms(
             self.sensor_model.a_est, self.sensor_model.b_est, data[8], data[9], data[10]

--- a/Subaqueous.py
+++ b/Subaqueous.py
@@ -107,8 +107,7 @@ class Subaqueous:
         a_h = fit_thu["a"]
         b_h = fit_thu["b"]
         # THU is a Linear fit: a + b*x 
-        # Multiply by 0.577 to convert from a uniform distribution to a Gaussian distribution.
-        res_thu = (a_h + b_h * self.depth)* 0.577
+        res_thu = (a_h + b_h * self.depth)
 
         # Check classification values.
         for i, classification in enumerate(self.classification):
@@ -426,8 +425,7 @@ class Subaqueous:
                 # Use the deep narrow uncertainty coefficients and offset. 
                 else:   
                     # THU is a Linear fit: a + b*x
-                    # Multiply THU by 0.577 to approximate Gaussian spread 
-                    thu_point = (a_h_narrow + (b_h_narrow * depth_point))* 0.577 
+                    thu_point = (a_h_narrow + (b_h_narrow * depth_point))
                     # TVU is an IHO fit: (a^2+(b*x)^2)^0.5
                     bx_h_narrow = (b_z_narrow * depth_point)
                     tvu_point = sqrt((a_z_narrow*a_z_narrow) + (bx_h_narrow*bx_h_narrow))

--- a/Tpu.py
+++ b/Tpu.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-August 4th, 2025
+May 12th, 2026
 """
 
 import logging
@@ -138,9 +138,8 @@ class Tpu:
 
                 # unsorted_las has the same order as points in las (i.e., unordered)
                 fl_idx = flight_lines == fl
+                fl_las_idx = np.nonzero(fl_idx)[0]   # stable index into the original LAS order
                 fl_unsorted_las = unsorted_las[fl_idx]
-                fl_t_argsort = t_argsort[fl_idx]
-                fl_las_idx = t_argsort.argsort()[fl_idx]
 
                 num_fl_points = np.sum(fl_idx)  # count Trues
                 logger.tpu(f"{las.las_short_name} fl {fl}: {num_fl_points} points")
@@ -152,13 +151,15 @@ class Tpu:
                 )
 
                 merged_data, stddev, unsort_idx, raw_class, masked_fan_angle, masked_hawkeye_data  = merge.merge(
-                    las,
+                    las.las_short_name,
                     fl,
                     sbet.values,
                     fl_unsorted_las,
-                    fl_t_argsort,
                     fl_las_idx,
                     self.sensor_object,
+                    # context_label=f"{las.las_short_name} FL {fl}", #DEBUGGING
+                    # debug_target=(t_las, x_las, y_las, z_las) ex: debug_target=(415394516.5950186, 389106.83, 4299188.75, -0.43), #DEBUGGING
+
                 )
 
                 if merged_data is not False:  # i.e., las and sbet is merged
@@ -166,7 +167,7 @@ class Tpu:
                     logger.tpu(
                         "({}) calculating subaer thu/tvu...".format(las.las_short_name)
                     )
-                    subaer_obj = Subaerial(jacobian, merged_data, stddev)
+                    subaer_obj = Subaerial(jacobian, merged_data, stddev, las_idx=unsort_idx)
 
                     subaer_thu, subaer_tvu = subaer_obj.calc_subaerial_tpu()
 
@@ -229,6 +230,26 @@ class Tpu:
                         total_tvu = np.sqrt(
                             subaer_tvu**2 + subaqu_tvu**2 + vdatum_mcu**2 + vuc**2 + range_bias**2
                         )
+
+                    # Debugging: print a few sample values of the uncertainty components and total TPU, 1 sigma only
+                    # uncertainty_components = pd.DataFrame({
+                    #     "subaer_thu": subaer_thu,
+                    #     "subaqu_thu": subaqu_thu,
+                    #     "subaer_tvu": subaer_tvu,
+                    #     "subaqu_tvu": subaqu_tvu,
+                    #     "vdatum_mcu": vdatum_mcu,
+                    #     "range_bias": range_bias if self.sensor_object.type != "multi" else None,
+                    #     "total_thu": total_thu,
+                    #     "total_tvu": total_tvu
+                    # })
+
+                    # # get csv path for printing uncertainty components
+                    # comp_csv_name = os.path.join(self.gui_object.output_directory, f"uncertainty_components_{las.las_short_name}_fl{fl}.csv")
+                    # logger.tpu(f"Saving uncertainty components CSV as {comp_csv_name}")
+                    # try:
+                    #     uncertainty_components.to_csv(comp_csv_name, index=False)
+                    # except ValueError as e:
+                    #     raise ValueError("CSV writing failed for uncertainty components")
 
                     # convert to 95% conf, if requested
                     if self.gui_object.error_type == "95% confidence":
@@ -344,7 +365,7 @@ class Tpu:
         for field in in_las.point_format:
 
             las_data = in_las[field.name]
-            in_las[field.name] = las_data[las.t_argsort]
+            in_las[field.name] = las_data
         # print(in_las.header)
         # print(in_las.vlrs)
 
@@ -373,24 +394,17 @@ class Tpu:
             # print(f"extra_byte_dims: {extra_byte_dimensions}")
             # print(f"extra_byte_df: {extra_byte_df}")
 
-            if extra_byte_df.shape[0] == las.num_file_points:
-                extra_byte_df = extra_byte_df.sort_index()
-                # print(f"extra_byte_df\n-------------")
-                # print(extra_byte_df)
-
-            else:
-
-                logger.tpu(
-                    """
-                filling data points for which TPU was not calculated
-                with no_data_value (also sorting by index, or t_idx)
+            logger.tpu(
                 """
-                )
-                no_data_value = -1
+            filling data points for which TPU was not calculated
+            with no_data_value ( also sorting by index, or t_idx)
+            """
+            )
+            no_data_value = -1
 
-                extra_byte_df = extra_byte_df.reindex(
-                    las.t_argsort, fill_value=no_data_value
-                ).sort_index()
+            extra_byte_df = extra_byte_df.reindex(
+                np.arange(las.num_file_points), fill_value=no_data_value
+            )
 
             logger.tpu("populating extra byte data for total_thu...")
             in_las.total_thu = extra_byte_df["total_thu"]
@@ -430,25 +444,17 @@ class Tpu:
             # print(f"out_csv_name{out_csv_name}")
             # print(f"out_las_name{out_las_name}")
 
-            # try:
-            #     csv_las = Las(out_las_name)
-            # except ValueError as e:
-            #     raise ValueError(f"Error: {e}, Laspy failed to read {out_las_name}")
-
-            #xyz_to_coordinate converts the x, y, z integer values to decimal values
-            x, y, z = las.xyz_to_coordinate()
-
             try:
                 # Save relevant data to csv
                 pd.DataFrame.from_dict(
                     {
-                        "GPS Time": in_las.gps_time,
-                        "X": x,
-                        "Y": y,
-                        "Z": z,
-                        "THU": in_las.total_thu,
-                        "TVU": in_las.total_tvu,
-                        "Classification": in_las.classification,
+                        "GPS Time": np.asarray(in_las.gps_time),
+                        "X": np.asarray(in_las.x),
+                        "Y": np.asarray(in_las.y),
+                        "Z": np.asarray(in_las.z),
+                        "THU": np.asarray(in_las.total_thu),
+                        "TVU": np.asarray(in_las.total_tvu),
+                        "Classification": np.asarray(in_las.classification),
                     }
                 ).to_csv(out_csv_name, index=False)
             except ValueError as e:

--- a/Tpu.py
+++ b/Tpu.py
@@ -167,7 +167,7 @@ class Tpu:
                     logger.tpu(
                         "({}) calculating subaer thu/tvu...".format(las.las_short_name)
                     )
-                    subaer_obj = Subaerial(jacobian, merged_data, stddev, las_idx=unsort_idx)
+                    subaer_obj = Subaerial(jacobian, merged_data, stddev)
 
                     subaer_thu, subaer_tvu = subaer_obj.calc_subaerial_tpu()
 

--- a/cblue_configuration.json
+++ b/cblue_configuration.json
@@ -12,6 +12,7 @@
         "40",
         "43"
     ],
+    "sbet_buffer": 1250,
     "sensor_model": "",
     "water_surface_ellipsoid_height": -28.0,
     "error_type": "95% confidence"

--- a/cblue_configuration.json
+++ b/cblue_configuration.json
@@ -6,7 +6,7 @@
     },
     "multiprocess": "False",
     "number_cores": 4,
-    "cBLUE_version": "v4.1",
+    "cBLUE_version": "v4.2",
     "subaqueous_version": "v3.1",
     "subaqueous_classes": [
         "40",

--- a/cblue_configuration.json
+++ b/cblue_configuration.json
@@ -12,7 +12,6 @@
         "40",
         "43"
     ],
-    "sbet_buffer": 1250,
     "sensor_model": "",
     "water_surface_ellipsoid_height": -28.0,
     "error_type": "95% confidence"


### PR DESCRIPTION
- Use time to truncate the combined SBET trajectory values instead of geographic bounds. This fixes a bug that can cause merging the SBET and LAS to fail. Too restrictive geographic bounds during original truncation was removing valid SBET data before merging. Truncating the data on time ensures that all relevant SBET data makes it to the merging step. 
- Added parallelization to the loading of SBET data files. 
- Modified Merge.py's match_timestamps() logic, it now matches LAS points to the nearest SBET time value forward or back in time, instead of only looking forward. This gives matching more deterministic merging logic if points are added or removed from the LAS file. Ona timestamp tie, always chooses the previous SBET point. Uses a more stable sorting function. Uses integer time ticks to avoid floating-point errors. If multiple SBET points share the same timestamp, use SBET point closest in space to the LAS point.
- Added optional detailed debugging statements for merge verification. Can be used by modifying Tpu.py's calc_tpu()'s call to Merge.merge().
- Add optional debugging to write uncertainty component csv in Tpu.py. Can be used by uncommenting the block of debugging code at the bottom of TPU.py's calc_tpu().
- Improve sampling of data for the error model using polynomial surface fitting in Subaerial.py's calc_poly_surf_coeffs(). This fixes a bug where the output values of the subaerial uncertainty component can vary wildly in small datasets when a points are added or removed from the LAS file. For speed gains, the merged data is subsampled to create the surface fit. This was previously too restrictive of subsampling for small datasets. The fixed subsampling was replaced with a stable hash selector that adaptively relaxes the subsampling to target a minimum number of fit points (50 min_pts). For datasets smaller than 100 points, all the data is used to generate the polynomial surface fit. 
- Removed THU conversion to gaussian spread in Subaqueous.py. 